### PR TITLE
Fixing small text issues in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ To edit the Docs you need to 'fork' the DroidScript repository. The easiest way 
 When the Codespace is open, navigate to the files/markup/en directory and make changes on any file you want to contribute. DroidScript has multiple scopes each having its own subdirectory with every possible method defined as _markup.js_ file. Inside you can modify the description, subfunctions, parameters and more. Make sure to follow the [markup format](files/markup/README.md)!
 
 ### Commit Changes
-When you finished your changes switch to the git tab on the left and descibe briefly what you have changed in the commit message field. The first line should describe what you did in general and each following line should include a more detailed list of your changes.\
-After that commit and synchronize your changes to GitHub with the green button below. If you just opened the Codespace on the DroidScript repository it will ask to create a fork.
+When you finish your changes, switch to the Git tab on the left and describe briefly what you have changed in the commit message field. The first line should describe what you did in general and each following line should include a more detailed list of your changes.\
+After that, commit and synchronize your changes to GitHub with the green button below. If you just opened the Codespace on the DroidScript repository it will ask to create a fork.
 
 **Note:** there is an ongoing Codespace bug that prevents you from committing to your fork. If that applies to you, open your workspace terminal and execute `git push --set-upstream origin master`
 
@@ -55,7 +55,7 @@ When you are satisfied with your changes and want us to review your changes, go 
 <p align="center"><img src="files/Screenshot-PullRequest.jpg" alt="Pull Request Dialog" width="100%" style="max-width:1000px"></p>
 
 ### Check on your Pull Request
-When a developer is satisfied with the request he will merge them into the DroidScript repository. If not he will leave a comment on [your pull request](https://github.com/DroidScript/Docs/pull/60) so make sure to regulary check on it until it gets approved, and enable notifications.
+When a developer is satisfied with the request, they will merge it into the DroidScript repository. If not, they will leave a comment on [your pull request](https://github.com/DroidScript/Docs/pull/60) so make sure to regularly check on it until it gets approved, and enable notifications.
 
 <div style="text-align:center">
 <b><big>Thank you for your contribution and support of </strong>DroidScript.org</strong>.!</big></b>

--- a/files/README.md
+++ b/files/README.md
@@ -6,8 +6,8 @@
 ### File Structure
 ```bash
 files/
-├─ json/         # intermediate json docs definitons
-├─ markup/       # markup docs definitons
+├─ json/         # intermediate JSON docs definitions
+├─ markup/       # markup docs definitions
 ├─ docs-base/    # docs template folder for every language/version
 ├─ font-awesome/ # belongs to docs-base
 │

--- a/files/json/README.md
+++ b/files/json/README.md
@@ -19,7 +19,7 @@
 		- [Custom Constructor positions](#custom-constructor-positions)
 		- [Custom Sample positions](#custom-sample-positions)
 	- [Generating](#generating)
-	- [Update Github Pages](#update-github-pages)
+    - [Update GitHub Pages](#update-github-pages)
 
 ## File Structure
 
@@ -54,7 +54,7 @@ json/<lang>/<ver>/<scope>/
 └─ samples<member>.txt   # large code examples
 ```
 
-Note: in fact, no file is reqired all the times. Following rules apply:
+Note: in fact, no file is required at all times. The following rules apply:
 - If _obj.json_ is defined, it can make use of _desc/\<member\>.md_ **and** _base.json_
 - If _obj.json_ is **not** defined, the description files in the _desc/_ directory will be used as scope contents
 - If _navs.json_ is **not** defined, the scope members (from _obj.json_ or _desc/_) will be listed as flat index (similar to the 'All' category)
@@ -322,14 +322,14 @@ If you want to put a sample of a sample.txt file to a specified position in your
 
 - in a terminal navigate to _'files'_ by executing `$ cd files`
 - execute `$ ./generate.js` to generate all docs of every language (`./generate.js` and `node generate.js` are synonym)
-- execute `$ ./generate.js -c` to foce a clean regeneration
+- execute `$ ./generate.js -c` to force a clean regeneration
 - execute `$ ./generate.js -help` to see more cli help
 - execute `$ ./generate.js <lang> [..]` to generate docs of a specific language
 - execute `$ ./generate.js <scope> [..]` to generate a specific scope
 - execute `$ ./generate.js <scope>.<pattern> [..]` to generate only certain members of a scope (pattern is a contained regex. - ie. app.Create will generate all members containing 'Create')
 - execute `$ ./generate.js <lang>.<scope> [..]` to generate a specific scope of a language
 
-Note: the script will only generate a scope if any file of the scope gen folder has been modified since the last generation of this scope. disable this behaviour with the -clean option.
+Note: the script will only generate a scope if any file of the scope gen folder has been modified since the last generation of this scope. Disable this behaviour with the -clean option.
 
 <details>
 <summary><b>Full generate.js option list</b></summary>
@@ -362,7 +362,7 @@ MEMBER-PATTERN:             RegEx pattern
 ```
 </details>
 
-## Update Github Pages
+## Update GitHub Pages
 
 To publish the generated html files on GitHub Pages execute the `updatePages` script
 ```sh

--- a/files/markup/README.md
+++ b/files/markup/README.md
@@ -6,8 +6,8 @@ This folder contains all the markup files for all controls, methods, and compone
 
 ## Why JavaScript `.js` and NOT Markdown `.md`?
 
-### For **`API`** documentation, use **`Javascript`** file.
-It allows easy editing of documentation through markup comments in **jsdoc** format especially when working on function definitions. Also, when working in code editors such as VS Code, the syntax highlighting and autocompletion makes writing the comments more easy and fun.
+### For **`API`** documentation, use a **`JavaScript`** file.
+It allows easy editing of documentation through markup comments in **jsdoc** format, especially when working on function definitions. Also, when working in code editors such as VS Code, the syntax highlighting and autocompletion make writing the comments easier and more fun.
 
 ### For general purpose documentation use the **`Markdown`** file format.
 See **`"en/intro"`** folder for reference.
@@ -215,7 +215,7 @@ For **Data Types** with default description you can select from the list below.
 - **`num_mtu`:** "maximum transmission unit"
 - **`num_prc`:** "percent"
 - **`num_pxl`:** "pixel"
-- **`num_rad`:** "angle in radient (0..2*π)"
+- **`num_rad`:** "angle in radian (0..2*π)"
 - **`num_sec`:** "seconds"
 - **`str_acc`:** "account Email"
 - **`str_b64`:** "base64 encoded"

--- a/files/markup/README.md
+++ b/files/markup/README.md
@@ -1,6 +1,6 @@
 # DroidScript Markup
 
-This folder contains all the markup files for all controls, methods, and components of **DroidScript**'s **app** object. Each file is a JavaScript file that resembles a codebase with all the code removed and only the **comments** left.
+This folder contains all the markup files for all controls, methods, and components. Each file is a JavaScript file that resembles a codebase with all the code removed and only the **comments** left.
 
 > There is a VS Code Extension that generates docs on-the-fly and displays a preview live in the editor. Install it [here](https://marketplace.visualstudio.com/items?itemName=droidscript.droidscript-docs).
 

--- a/files/markup/README.md
+++ b/files/markup/README.md
@@ -7,7 +7,7 @@ This folder contains all the markup files for all controls, methods, and compone
 ## Why JavaScript `.js` and NOT Markdown `.md`?
 
 ### For **`API`** documentation, use **`Javascript`** file.
-It allows easy editing of documentation through markup comments in **jsdoc** format especially when working on function definitions. Also, when working on Code Editors such as VS Code, the syntax highlighting and autocompletion makes writing the comments more easy and fun.
+It allows easy editing of documentation through markup comments in **jsdoc** format especially when working on function definitions. Also, when working in code editors such as VS Code, the syntax highlighting and autocompletion makes writing the comments more easy and fun.
 
 ### For general purpose documentation use the **`Markdown`** file format.
 See **`"en/intro"`** folder for reference.


### PR DESCRIPTION
Fixes for #274 :

- Spelling
- "he" > "they"
- Minor grammar issues
- Added a couple commas for readability
- German capitalization

Not changing British spelling.

Merge with Beta.